### PR TITLE
[#15] Support ignore paths listed in `.gitignore`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "vscode-more-file-command",
       "version": "0.0.3",
+      "dependencies": {
+        "ignore": "^5.3.2"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "18.x",
@@ -1587,10 +1590,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-      "dev": true,
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "engines": {
         "node": ">= 4"
       }

--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "tsc-alias": "^1.8.8",
     "typescript": "^5.3.3"
   },
-  "packageManager": "npm@10.5.0"
+  "packageManager": "npm@10.5.0",
+  "dependencies": {
+    "ignore": "^5.3.2"
+  }
 }


### PR DESCRIPTION
Supports `.gitignore` files in subdirectories (=not in workspace root folder)
Closes #15 .