### PR TITLE
Change publish github action run condition

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -10,6 +10,8 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   # This event will only trigger a workflow run if the workflow file is on the default branch.
   workflow_dispatch:
+  # To indicate it can be called by another workflow.
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,19 @@
 name: publish
 on:
-  workflow_run:
-    workflows: ["code-check"]
-    types: [completed]
-    branches:
-      - main
+  push:
+    tags: 'v*'
 
   # Allows you to run this workflow manually from the Actions tab
   # This event will only trigger a workflow run if the workflow file is on the default branch.
   workflow_dispatch:
 
 jobs:
+  code-check:
+    uses: ./.github/workflows/code-check.yml
+
   publish:
+    needs:
+      - code-check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Before this PR, if code-check action ended before adding a git tag on the commit,
it could have silently ended without producing build output.
To prevent such behavior, Changed the condition to pushing a git tag, and run the check action as a job, duplicated or not.
There seems to be another way not to duplicate the check action run, but this seems to over-complicate the task.